### PR TITLE
Automake install-data-hook must respect $DESTDIR

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,6 @@ otr_la_LDFLAGS = -avoid-version -module
 otr_la_LDFLAGS += $(LIBOTR_LIBS) $(LIBGCRYPT_LIBS) -lpthread
 
 install-data-hook:
-	rm $(plugindir)/otr.la
-	mv $(plugindir)/otr.so $(plugindir)/libotr.so
-	chmod 644 $(plugindir)/libotr.so
+	rm $(DESTDIR)$(plugindir)/otr.la
+	mv $(DESTDIR)$(plugindir)/otr.so $(DESTDIR)$(plugindir)/libotr.so
+	chmod 644 $(DESTDIR)$(plugindir)/libotr.so


### PR DESCRIPTION
Signed-off-by: Christian Babeux christian.babeux@0x80.ca
