### PR TITLE
Fix OTR init message causing unknown command errors.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -26,6 +26,7 @@
 #include <glib/gstdio.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #include "cmd.h"
 #include "key.h"

--- a/src/otr.c
+++ b/src/otr.c
@@ -365,7 +365,7 @@ int otr_send(SERVER_REC *irssi, const char *msg, const char *to, char **otr_msg)
 	}
 	
 	/* Modify some libotr messages (OTR init in particular) to work better with IRC. */
-	if (otr_msg) utils_escape_message(*otr_msg);
+	if (*otr_msg) utils_escape_message(*otr_msg);
 
 	IRSSI_DEBUG("Message sent...");
 

--- a/src/otr.c
+++ b/src/otr.c
@@ -363,8 +363,8 @@ int otr_send(SERVER_REC *irssi, const char *msg, const char *to, char **otr_msg)
 		IRSSI_NOTICE(irssi, to, "Send failed.");
 		goto error;
 	}
-
-	/* Remove newlines. */
+	
+	/* Modify some libotr messages (OTR init in particular) to work better with IRC. */
 	if (otr_msg) utils_escape_message(*otr_msg);
 
 	IRSSI_DEBUG("Message sent...");

--- a/src/otr.c
+++ b/src/otr.c
@@ -364,6 +364,9 @@ int otr_send(SERVER_REC *irssi, const char *msg, const char *to, char **otr_msg)
 		goto error;
 	}
 
+	/* Remove newlines. */
+	if (otr_msg) utils_escape_message(*otr_msg);
+
 	IRSSI_DEBUG("Message sent...");
 
 	/* Add peer context to OTR context if none exists. */

--- a/src/otr.h
+++ b/src/otr.h
@@ -54,6 +54,10 @@
 #define OTR_MSG_BEGIN_TAG             "?OTR:"
 #define OTR_MSG_END_TAG               '.'
 
+#define OTR_MSG_HELP                  "  This is a request for an Off-the-Record private conversation. "\
+                                      "However, you do not have a plugin to support that. If you are using Irssi, "\
+                                      "please install irssi-otr (irssi-plugin-otr).";
+
 /* IRC /me command marker and len. */
 #define OTR_IRC_MARKER_ME             "/me "
 #define OTR_IRC_MARKER_ME_LEN         sizeof(OTR_IRC_MARKER_ME) - 1

--- a/src/utils.c
+++ b/src/utils.c
@@ -74,10 +74,19 @@ char *utils_trim_string(char *s)
 }
 
 /*
- * Convert invalid characters (newlines from libotr) into spaces
+ * Convert invalid characters (newlines from libotr) into spaces.
+ * Also change the init help string because IRC does not support HTML.
  */
 char *utils_escape_message(char *s) {
+	char const* helpmsg = OTR_MSG_HELP;
+	char* p;
 	size_t i;
+	if (strncmp(s, "?OTR", 4) == 0 && strstr(s, "</b> has requested an <a href")) {
+		i = strcspn(s, "\n");
+		if (i + strlen(helpmsg) <= strlen(s)) {
+			strcpy(s + i, helpmsg);
+		}
+	}
 	for (i = 0; s[i]; ++i) {
 		if (s[i] == '\n' || s[i] == '\r') s[i] = ' ';
 	}

--- a/src/utils.c
+++ b/src/utils.c
@@ -74,6 +74,17 @@ char *utils_trim_string(char *s)
 }
 
 /*
+ * Convert invalid characters (newlines from libotr) into spaces
+ */
+char *utils_escape_message(char *s) {
+	size_t i;
+	for (i = 0; s[i]; ++i) {
+		if (s[i] == '\n' || s[i] == '\r') s[i] = ' ';
+	}
+	return s;
+}
+
+/*
  * Extract question and secret for an SMP authentication.
  *
  * Return 0 and set question/secret on success. Else, return negative value and

--- a/src/utils.c
+++ b/src/utils.c
@@ -79,7 +79,6 @@ char *utils_trim_string(char *s)
  */
 char *utils_escape_message(char *s) {
 	char const* helpmsg = OTR_MSG_HELP;
-	char* p;
 	size_t i;
 	if (strncmp(s, "?OTR", 4) == 0 && strstr(s, "</b> has requested an <a href")) {
 		i = strcspn(s, "\n");

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,5 +29,6 @@ void utils_string_to_upper(char *string);
 int utils_auth_extract_secret(const char *_data, char **secret);
 void utils_hash_parts_to_readable_hash(const char **parts, char *dst);
 char *utils_trim_string(char *s);
+char *utils_escape_message(char *s);
 
 #endif /* IRSSI_OTR_UTILS_H */


### PR DESCRIPTION
Remove newline characters from libotr output and customize the OTR init message for IRC users.

Closes bug #33.