### PR TITLE
libotr >= 4.1.0 in configure.ac and spec file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AM_PATH_GLIB_2_0([2.22.0], [],
 
 AM_PATH_LIBGCRYPT(1:1.2.0,,AC_MSG_ERROR(libgcrypt 1.2.0 or newer is required.))
 
-AM_PATH_LIBOTR(4.0.0, [], [AC_MSG_ERROR([libotr 4.0.0 or newer is required.])])
+AM_PATH_LIBOTR(4.1.0, [], [AC_MSG_ERROR([libotr 4.1.0 or newer is required.])])
 
 pkg_modules="gmodule-2.0 >= 2.0.0"
 PKG_CHECK_MODULES(GMODULE, [$pkg_modules])

--- a/irssi-otr.spec.in
+++ b/irssi-otr.spec.in
@@ -9,7 +9,7 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  glib2-devel >= 2.13
 BuildRequires:  irssi-devel
-BuildRequires:  libotr-devel >= 4.0.0
+BuildRequires:  libotr-devel >= 4.1.0
 BuildRequires:  pkgconfig
 Requires:       irssi
 


### PR DESCRIPTION
Follow-up to 4ad3b7b6c85be0154ab3694fe9831796db20c4fe and issue #50 - specify minimum requirement of libotr >= 4.1.0 in configure.ac and spec file.