### PR TITLE
Fix error on self-messages with irssi versions after 0.8.17

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -32,6 +32,7 @@
 #include "otr.h"
 #include "otr-formats.h"
 #include "utils.h"
+#include "irssi-version.h"
 
 GCRY_THREAD_OPTION_PTHREAD_IMPL;
 
@@ -90,8 +91,13 @@ end:
 /*
  * Pipes all incoming private messages through OTR
  */
+#if IRSSI_VERSION_DATE > 20141206
 void sig_message_private(SERVER_REC *server, const char *msg,
-		const char *nick, const char *address)
+		const char *nick, const char *address, const char *target)
+#else
+void sig_message_private(SERVER_REC *server, const char *msg,
+                const char *nick, const char *address)
+#endif
 {
 	int ret;
 	char *new_msg = NULL;
@@ -106,7 +112,11 @@ void sig_message_private(SERVER_REC *server, const char *msg,
 
 	if (!new_msg) {
 		/* This message was not OTR */
-		signal_continue(4, server, msg, nick, address);
+#if IRSSI_VERSION_DATE > 20141206
+		signal_continue(5, server, msg, nick, address, target);
+#else
+                signal_continue(4, server, msg, nick, address);
+#endif
 	} else {
 		/*
 		 * Check for /me IRC marker and if so, handle it so the user does not

--- a/src/otr-ops.c
+++ b/src/otr-ops.c
@@ -21,6 +21,7 @@
 
 #include "key.h"
 #include "module.h"
+#include "irssi-version.h"
 
 static OtrlPolicy OTR_DEFAULT_POLICY =
 	OTRL_POLICY_MANUAL | OTRL_POLICY_WHITESPACE_START_AKE;
@@ -206,8 +207,13 @@ static void ops_handle_msg_event(void *opdata, OtrlMessageEvent msg_event,
 		 * submit a patch or email me a better way.
 		 */
 		signal_remove("message private", (SIGNAL_FUNC) sig_message_private);
-		signal_emit("message private", 4, server, message, username,
+#if IRSSI_VERSION_DATE > 20141206
+		signal_emit("message private", 5, server, message, username, server->nick,
 				IRSSI_CONN_ADDR(server));
+#else
+                signal_emit("message private", 4, server, message, username,
+                                IRSSI_CONN_ADDR(server));
+#endif
 		signal_add_first("message private", (SIGNAL_FUNC) sig_message_private);
 		break;
 	case OTRL_MSGEVENT_RCVDMSG_UNRECOGNIZED:


### PR DESCRIPTION
This commit fixes errors produced when the user atempts to send a mesasge to themselves,
caused by the he addition of a target parameter to the 'message private' signal in
https://github.com/irssi/irssi/commit/1edfcedda1105d79fa6b92d77a8fb60f296abe1e
