### PR TITLE
Implement Irssi ABI check.

### DIFF
--- a/src/otr.c
+++ b/src/otr.c
@@ -1105,3 +1105,8 @@ end:
 error:
 	return;
 }
+
+void otr_abicheck(int *version)
+{
+    *version = 1;
+}


### PR DESCRIPTION
The ABI check was introduced with https://github.com/irssi/irssi/pull/363 and if not provided the module will to load.

I stumbled over this while trying to get it running on OSX with irssi build from master (https://github.com/cryptodotis/irssi-otr/issues/40).