### PR TITLE
respect $PREFIX on install

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AC_SUBST(DEFAULT_INCLUDES)
 AC_ARG_WITH([irssi-module-dir],
 	AS_HELP_STRING([--with-irssi-module-dir=DIR], [Irssi module directory]),
 	[IRSSI_MODULE_DIR="$withval"],
-	[IRSSI_MODULE_DIR="/usr/lib/irssi/modules"])
+	[IRSSI_MODULE_DIR='${libdir}/irssi/modules'])
 
 AC_SUBST(IRSSI_MODULE_DIR)
 

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -1,6 +1,6 @@
 # The day Irssi will be able to check in $(prefix), this will change. Until
 # then, it's hardcoded.
-helpdir = /usr/share/irssi/help
+helpdir = $(datarootdir)/irssi/help
 help_DATA = otr
 
 EXTRA_DIST = otr

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = $(LIBOTR_CFLAGS) $(LIBGCRYPT_CFLAGS) $(PACKAGE_FLAGS)
 
-IRSSI_DIST=/usr/include/irssi
+IRSSI_DIST=$(includedir)/irssi
 IRSSI_INCLUDE = -I$(IRSSI_DIST) \
 				-I$(IRSSI_DIST)/src \
 				-I$(IRSSI_DIST)/src/fe-common/core \


### PR DESCRIPTION
$PREFIX is a very common convention when installing software,
especially with autoconf, which the OTR plugin uses.

This makes sure that the `--prefix` flag in configure affects all
relevant portions of the install code.

Closes #53.